### PR TITLE
fix bug on test button for secure clusters

### DIFF
--- a/app.js
+++ b/app.js
@@ -392,13 +392,16 @@ class ESMonitor {
 
     async testConnection() {
         const url = document.getElementById('esUrl').value.trim();
+        const username = document.getElementById('esUsername').value.trim();
+        const password = document.getElementById('esPassword').value.trim();
         if (!url) {
             Toast.show('Please enter Elasticsearch URL', 'error');
             return;
         }
 
         try {
-            const service = new ElasticsearchService(url);
+            const auth = username && password ? { username, password } : null;
+            const service = new ElasticsearchService(url, auth);
             const isConnected = await service.checkConnection();
             
             if (isConnected) {


### PR DESCRIPTION
Hi, I discovered a bug with the "Test" button. When a user tries to test the connection on a secure cluster, it always returns an error because the username and password are not being passed to the method. However, clicking the "Connect" button works correctly and the connection is successful.