### PR TITLE
add "hide system indices button" to index datatable

### DIFF
--- a/app.js
+++ b/app.js
@@ -24,6 +24,9 @@ class ESMonitor {
         this.indicesRepository = null;
         this.eventBus = EventBus;
         this.languageManager = new LanguageManager();
+        this.hideSystemIndicesTable = true;
+        this.isUpdatingIndicesTable = false;
+        this.isUpdatingDashboard = false;
         this.components = {
             clusterHealth: new ClusterHealth('clusterHealth'),
             shardDistribution: new ShardDistribution('shards')
@@ -35,6 +38,13 @@ class ESMonitor {
         document.addEventListener('languageChanged', (e) => {
             this.onLanguageChanged(e.detail.language);
         });
+        
+        setTimeout(() => {
+            const checkbox = document.getElementById('toggleSystemIndicesTable');
+            if (checkbox) {
+                this.hideSystemIndicesTable = checkbox.checked;
+            }
+        }, 100);
         
         this.initializeEventListeners();
         this.initializeModalHandlers();
@@ -91,6 +101,14 @@ class ESMonitor {
                 const isHidden = this.components.shardDistribution.toggleSystemIndices();
                 toggleSystemIndices.checked = isHidden;
                 await this.updateShardDistribution();
+            });
+        }
+
+        const toggleSystemIndicesTable = document.getElementById('toggleSystemIndicesTable');
+        if (toggleSystemIndicesTable) {
+            toggleSystemIndicesTable.addEventListener('change', async () => {
+                this.hideSystemIndicesTable = toggleSystemIndicesTable.checked;
+                await this.updateDashboard();
             });
         }
 
@@ -454,6 +472,11 @@ class ESMonitor {
                 
                 document.getElementById('dashboard').classList.remove('hidden');
 
+                const checkbox = document.getElementById('toggleSystemIndicesTable');
+                if (checkbox) {
+                    this.hideSystemIndicesTable = checkbox.checked;
+                }
+
                 this.quickFilter = new QuickFilter(this.esService);
                 
                 if (this.search) {
@@ -489,6 +512,12 @@ class ESMonitor {
     }
 
     async updateDashboard() {
+        if (this.isUpdatingDashboard) {
+            return;
+        }
+        
+        this.isUpdatingDashboard = true;
+        
         try {
             const [clusterInfo, health, stats, indices, shardDistribution] = await Promise.all([
                 this.esService.getClusterInfo(),
@@ -535,11 +564,40 @@ class ESMonitor {
 
         } catch (error) {
             Toast.show(`Failed to update dashboard: ${error.message}`, 'error');
+        } finally {
+            this.isUpdatingDashboard = false;
         }
     }
 
     async updateIndicesTable(indices) {
-        const formattedIndices = await this.indicesRepository.getAllIndices();
+        if (this.isUpdatingIndicesTable) {
+            return;
+        }
+        
+        this.isUpdatingIndicesTable = true;
+        
+        try {
+            let formattedIndices = await this.indicesRepository.getAllIndices();
+            
+            const checkbox = document.getElementById('toggleSystemIndicesTable');
+            if (checkbox) {
+                this.hideSystemIndicesTable = checkbox.checked;
+            }
+            
+            if (this.hideSystemIndicesTable) {
+                formattedIndices = formattedIndices.filter(index => 
+                    !index.index.startsWith('.') && !index.index.startsWith('_')
+                );
+            }
+            
+            if (!Array.isArray(formattedIndices)) {
+                formattedIndices = [];
+            }
+            
+            if ($.fn.DataTable.isDataTable('#indicesTable')) {
+                $('#indicesTable').DataTable().destroy();
+                $('#indicesTable tbody').empty();
+            }
 
         if (!$.fn.DataTable.isDataTable('#indicesTable')) {
             $('#indicesTable').DataTable({
@@ -648,9 +706,6 @@ class ESMonitor {
                      "rt" +
                      "<'dt-bottom'<'dataTables_info'i><'dataTables_paginate'p>>"
             });
-        } else {
-            const table = $('#indicesTable').DataTable();
-            table.clear().rows.add(formattedIndices).draw();
         }
         
         setTimeout(() => {
@@ -658,6 +713,12 @@ class ESMonitor {
                 this.languageManager.updateUI();
             }
         }, 100);
+        } catch (error) {
+            console.error('Error updating indices table:', error);
+            Toast.show('Failed to update indices table', 'error');
+        } finally {
+            this.isUpdatingIndicesTable = false;
+        }
     }
 
     showError(message) {
@@ -689,6 +750,12 @@ class ESMonitor {
                     const isConnected = await this.esService.checkConnection();
                     if (isConnected) {
                         document.getElementById('dashboard').classList.remove('hidden');
+                        
+                        const checkbox = document.getElementById('toggleSystemIndicesTable');
+                        if (checkbox) {
+                            this.hideSystemIndicesTable = checkbox.checked;
+                        }
+                        
                         this.quickFilter = new QuickFilter(this.esService);
                         
                         if (this.search) {

--- a/index.html
+++ b/index.html
@@ -260,9 +260,18 @@
             <div id="indices" class="indices-panel">
                 <div class="panel-header">
                     <h2><i class="fa-solid fa-table"></i> <span data-translate="indices.title">Indices</span></h2>
-                    <button id="createIndexBtn" class="secondary">
-                        <i class="fa-solid fa-plus"></i> <span data-translate="indices.createIndex">Create Index</span>
-                    </button>
+                    <div class="header-actions">
+                        <div class="toggle-container">
+                            <label class="toggle-switch">
+                                <input type="checkbox" id="toggleSystemIndicesTable" checked>
+                                <span class="toggle-slider"></span>
+                            </label>
+                            <span class="toggle-label" data-translate="indices.hideSystemIndices">Hide System Indices</span>
+                        </div>
+                        <button id="createIndexBtn" class="secondary">
+                            <i class="fa-solid fa-plus"></i> <span data-translate="indices.createIndex">Create Index</span>
+                        </button>
+                    </div>
                 </div>
                 <div class="indices-table-container">
                     <table id="indicesTable" class="indices-table">

--- a/src/utils/translations.js
+++ b/src/utils/translations.js
@@ -49,6 +49,7 @@ const translations = {
         indices: {
             title: "Indices",
             createIndex: "Create Index",
+            hideSystemIndices: "Hide System Indices",
             indexName: "Index Name",
             docsCount: "Docs Count",
             size: "Size",
@@ -251,6 +252,7 @@ const translations = {
         indices: {
             title: "索引",
             createIndex: "创建索引",
+            hideSystemIndices: "隐藏系统索引",
             indexName: "索引名称",
             docsCount: "文档数量",
             size: "大小",

--- a/styles/features/indices.css
+++ b/styles/features/indices.css
@@ -18,6 +18,12 @@
     color: var(--text-primary);
 }
 
+.panel-header .header-actions {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+}
+
 .indices-panel .panel-header button {
     padding: 0.625rem 1rem;
     border-radius: 6px;


### PR DESCRIPTION
While working with Elasticsearch clusters, system indices can be annoying. There are also several open issues related to this topic.
I added a "Hide System Indices" button to the indices table, similar to the one in the "Shard Distribution" tab.

During this process, I discovered a race condition in the indices table by chance. If you refresh the table multiple times, it gets stuck and becomes unresponsive. I implemented a fix for this race condition, and I believe this issue should no longer occur. (Unfortunately, I couldn’t reproduce the issue locally again so I expect it to be resolved 😅 )

race condition issue looked like this:
<img width="1900" height="596" alt="image" src="https://github.com/user-attachments/assets/d3a6c4ed-95b4-4276-ae2e-fcb6f4fefad5" />


I tested the "Hide System Indices" button locally, and it's working fine.

<img width="1879" height="635" alt="image" src="https://github.com/user-attachments/assets/981bc9b3-5dbb-4ac3-9cc7-59c95505a723" />

<img width="1877" height="511" alt="image" src="https://github.com/user-attachments/assets/ad99012e-58eb-43f7-a6e4-a29b40b40f67" />

